### PR TITLE
Fix activate member Class service code snippet

### DIFF
--- a/3. Creating and Calling Custom APIs/1. ActivateMembershipAppService Class.md
+++ b/3. Creating and Calling Custom APIs/1. ActivateMembershipAppService Class.md
@@ -28,7 +28,7 @@ namespace Boxfusion.Membership.Common.Services
             var member = await _memberRepo.GetAsync(memberId);
             var payments = await _membershipPaymentRepo.GetAllListAsync(data => data.Member.Id == memberId);
 
-            if (payments.Count == 0) throw new UserFriendlyException("There no payments made");
+            if (payments.Count == 0) throw new UserFriendlyException("There are no payments made");
 
             double totalAmount = 0;
             payments.ForEach(a =>

--- a/3. Creating and Calling Custom APIs/1. ActivateMembershipAppService Class.md
+++ b/3. Creating and Calling Custom APIs/1. ActivateMembershipAppService Class.md
@@ -28,7 +28,7 @@ namespace Boxfusion.Membership.Common.Services
             var member = await _memberRepo.GetAsync(memberId);
             var payments = await _membershipPaymentRepo.GetAllListAsync(data => data.Member.Id == memberId);
 
-            if (payments.Count = 0) throw new UserFriendlyException("There no payments made");
+            if (payments.Count == 0) throw new UserFriendlyException("There no payments made");
 
             double totalAmount = 0;
             payments.ForEach(a =>


### PR DESCRIPTION
The code used a single '=' instead of a double '==' when counting the payments causing a compile error

There is also a correction in the grammar of the error returned if there are no payments